### PR TITLE
Fix confusing message in toggle state func

### DIFF
--- a/evil-lisp-state.el
+++ b/evil-lisp-state.el
@@ -250,9 +250,11 @@ If `evil-lisp-state-global' is non nil then this variable has no effect."
 (defun lisp-state-toggle-lisp-state ()
   "Toggle the lisp state."
   (interactive)
-  (message "state: %s" evil-state)
   (if (eq 'lisp evil-state)
-      (evil-normal-state)
+      (progn
+        (message "state: lisp -> normal")
+        (evil-normal-state))
+    (message "state: %s -> lisp" evil-state)
     (evil-lisp-state)))
 
 (defun lisp-state-wrap (&optional arg)


### PR DESCRIPTION
I find the message about the state confusing, because it's reporting the state you left not the current one. 