### PR TITLE
Fix some minor issues with bind-map

### DIFF
--- a/evil-lisp-state.el
+++ b/evil-lisp-state.el
@@ -111,6 +111,7 @@
 
 (require 'evil)
 (require 'smartparens)
+(require 'bind-map)
 
 (evil-define-state lisp
   "Lisp state.
@@ -168,13 +169,15 @@ If `evil-lisp-state-global' is non nil then this variable has no effect."
 ;; leader maps
 (defun evil-lisp-state-leader (leader)
   "Set LEADER."
-  (bind-map evil-lisp-state-map
-    :evil-keys (leader)
-    :evil-states (normal))
-  (bind-map evil-lisp-state-major-modes-map
-    :evil-keys (leader)
-    :evil-states (normal)
-    :major-modes (evil-lisp-state-major-modes)))
+  (eval
+   `(progn
+      (bind-map evil-lisp-state-map
+        :evil-keys (,leader)
+        :evil-states (normal))
+      (bind-map evil-lisp-state-major-modes-map
+        :evil-keys (,leader)
+        :evil-states (normal)
+        :major-modes ,evil-lisp-state-major-modes))))
 (evil-lisp-state-leader "SPC l")
 
 ;; escape


### PR DESCRIPTION
Require the package and fix a compiler warning about leader not being
defined when the macro is expanded in evil-lisp-state-leader.