### PR TITLE
Don't bind major-mode map when evil-lisp-state-global

### DIFF
--- a/evil-lisp-state.el
+++ b/evil-lisp-state.el
@@ -170,15 +170,16 @@ If `evil-lisp-state-global' is non nil then this variable has no effect."
 ;; leader maps
 (defun evil-lisp-state-leader (leader)
   "Set LEADER."
-  (bind-map evil-lisp-state-map
-    :evil-use-local t
-    :evil-keys (leader)
-    :evil-states (normal))
-  (eval
-   `(bind-map evil-lisp-state-major-mode-map
-      :evil-keys (,leader)
-      :evil-states (normal)
-      :major-modes ,evil-lisp-state-major-modes)))
+  (if evil-lisp-state-global
+      (bind-map evil-lisp-state-map
+        :evil-use-local t
+        :evil-keys (leader)
+        :evil-states (normal))
+    (eval
+     `(bind-map evil-lisp-state-major-mode-map
+        :evil-keys (,leader)
+        :evil-states (normal)
+        :major-modes ,evil-lisp-state-major-modes))))
 
 ;; escape
 (define-key evil-lisp-state-map [escape] 'evil-normal-state)

--- a/evil-lisp-state.el
+++ b/evil-lisp-state.el
@@ -123,6 +123,10 @@
   ;; force smartparens mode
   (if (evil-lisp-state-p) (smartparens-mode)))
 
+(defvar evil-lisp-state-major-mode-map (make-sparse-keymap)
+  "Keymap used by evil-lisp-state when `evil-lisp-state-global'
+is nil.")
+
 (defgroup evil-lisp-state nil
   "Evil lisp state."
   :group 'emulations


### PR DESCRIPTION
When this variable is non nil this map receives no bindings, so we
shouldn't bind it in this case.

Fixes https://github.com/syl20bnr/spacemacs/issues/4151