### PR TITLE
Only switch to evil lisp state if in evil mode

### DIFF
--- a/evil-lisp-state.el
+++ b/evil-lisp-state.el
@@ -154,7 +154,7 @@ If `evil-lisp-state-global' is non nil then this variable has no effect."
     `(progn
        (defun ,funcname ()
         (interactive)
-        (when evil-lisp-state-enter-lisp-state-on-command
+        (when (and evil-state evil-lisp-state-enter-lisp-state-on-command)
           (evil-lisp-state))
         (call-interactively ',command))
        ',funcname)))


### PR DESCRIPTION
This is to support this in hybrid environments where users may not be
using evil mode at all, or may be using evil mode in some situations.

I really like what your doing with spacemacs.  But I'm finding some inconsistencies when running in holy mode, this package assumes that you are in an Evil mode and then forces you into it.  But at the same time i want to be friendly to people running in a hybrid environment.  So this is my attempt to only switch to evil if your already in an evil mode.  There may be a better condition that could go in there.  I've only been using spacemacs for 2 days.
