### PR TITLE
Fix end-of-line movement

### DIFF
--- a/evil-lisp-state.el
+++ b/evil-lisp-state.el
@@ -329,7 +329,7 @@ If `evil-lisp-state-global' is non nil then this variable has no effect."
     (evil-insert-state)
     (sp-newline)
     (evil-previous-visual-line)
-    (evil-end-of-line)
+    (end-of-line)
     (insert " ")
     (sp-insert-pair "(")
     (indent-for-tab-command)))


### PR DESCRIPTION
`evil-end-of-line` brings us one character away from end of line (as it should be in normal state, but not in insert state)

Fixes #28
