### PR TITLE
Restore smartparens state on exit

### DIFF
--- a/evil-lisp-state.el
+++ b/evil-lisp-state.el
@@ -115,10 +115,12 @@
 (require 'bind-map)
 
 (defun evil-lisp-restore-smartparens-state()
-  (when (and (boundp 'evil-lisp-state-smartparens-keep) (not evil-lisp-state-smartparens-keep))
+  (when (and (boundp 'evil-lisp-state-smartparens-keep)
+             (not evil-lisp-state-smartparens-keep))
     (smartparens-mode -1)))
 
-(add-hook 'evil-lisp-state-exit-hook #'evil-lisp-restore-smartparens-state)
+(add-hook 'evil-lisp-state-exit-hook
+          #'evil-lisp-restore-smartparens-state)
 
 (evil-define-state lisp
   "Lisp state.
@@ -126,11 +128,11 @@
   :tag " <L> "
   :suppress-keymap t
   :cursor (bar . 2)
-  (if (evil-lisp-state-p)
-    (progn
-      (setq-local evil-lisp-state-smartparens-keep (symbol-value 'smartparens-mode))
+  (when (evil-lisp-state-p)
+      (setq-local evil-lisp-state-smartparens-keep
+                  (symbol-value 'smartparens-mode))
       ;; force smartparens mode
-      (smartparens-mode))))
+      (smartparens-mode)))
 
 (defgroup evil-lisp-state nil
   "Evil lisp state."

--- a/evil-lisp-state.el
+++ b/evil-lisp-state.el
@@ -114,14 +114,23 @@
 (require 'smartparens)
 (require 'bind-map)
 
+(defun evil-lisp-restore-smartparens-state()
+  (when (and (boundp 'evil-lisp-state-smartparens-keep) (not evil-lisp-state-smartparens-keep))
+    (smartparens-mode -1)))
+
+(add-hook 'evil-lisp-state-exit-hook #'evil-lisp-restore-smartparens-state)
+
 (evil-define-state lisp
   "Lisp state.
  Used to navigate lisp code and manipulate the sexp tree."
   :tag " <L> "
   :suppress-keymap t
   :cursor (bar . 2)
-  ;; force smartparens mode
-  (if (evil-lisp-state-p) (smartparens-mode)))
+  (if (evil-lisp-state-p)
+    (progn
+      (setq-local evil-lisp-state-smartparens-keep (symbol-value 'smartparens-mode))
+      ;; force smartparens mode
+      (smartparens-mode))))
 
 (defgroup evil-lisp-state nil
   "Evil lisp state."


### PR DESCRIPTION
Currently I'm using parinfer-mode alongside evil-lisp-state in my spacemacs setup. 
The former isn't compatible with smartparens, while the latter depends on it.

As far as I can see, this setup works when smartparens is deactivated in insert/hybrid mode, where parinfer is active.  But evil-lisp-state forces activation of smartparens, and then leaves it active. 

This is an attempt to restore previous smartparens state when exiting lisp-state.